### PR TITLE
ci: bump deprecated Node-20 actions to Node-24 majors

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -19,12 +19,12 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -281,7 +281,7 @@ jobs:
         "PACKAGE_NAME=$packageName" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ steps.version.outputs.PACKAGE_NAME }}
         path: |


### PR DESCRIPTION
## Summary

GitHub is forcing Node-20 GitHub Actions onto the Node-24 runtime on **2026-06-16**. This PR bumps affected actions to their lowest available Node-24 major to minimise breaking-change risk.

## Bumped

| Action | Old | New | Notes |
|--------|-----|-----|-------|
| `actions/checkout` | v4 (node20) | v5 (node24) | |
| `actions/setup-dotnet` | v4 (node20) | v5 (node24) | |
| `actions/upload-artifact` | v4 (node20) | v6 (node24) | v5 is still node20, so jumped to v6 |

## Left as-is

None — all deprecated actions in this repo have a node24 major available.

## Review notes

- `actions/upload-artifact` skipped v5 (still node20) and landed on **v6** — verify that the `path:` multi-line glob input is still supported (it is; v6 preserved that interface).
- `softprops/action-gh-release@v1` and `KamaranL/add-signtool-action@v1` were not in the deprecated list and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)